### PR TITLE
Templatize storageClassName for bcd indexer

### DIFF
--- a/charts/tezos/templates/bcd_indexer.yaml
+++ b/charts/tezos/templates/bcd_indexer.yaml
@@ -87,6 +87,7 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
+        storageClassName: {{ .Values.bcd_indexer_statefulset.storageClassName }}
         resources:
           requests:
             storage: "300Gi"
@@ -95,6 +96,7 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
+        storageClassName: {{ .Values.bcd_indexer_statefulset.storageClassName }}
         resources:
           requests:
             storage: "5Gi"
@@ -103,6 +105,7 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
+        storageClassName: {{ .Values.bcd_indexer_statefulset.storageClassName }}
         resources:
           requests:
             storage: "300Gi"
@@ -111,9 +114,10 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
+        storageClassName: {{ .Values.bcd_indexer_statefulset.storageClassName }}
         resources:
           requests:
-            storage: "1Gi"
+            storage: "100Gi"
 
 ---
 apiVersion: v1

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -34,6 +34,7 @@ nomadic_indexer_statefulset:
   name: nomadic-indexer
 bcd_indexer_statefulset:
   name: bcd-indexer
+  storageClassName: ""
 
 # For non-public chains the defualt mutez given to an account if the
 # account is not explicitly set below.


### PR DESCRIPTION
Also up shared-volume size to 100gb. For some reason 1gb is not enough even thou Baking Bad says it is.